### PR TITLE
feat: Create parent child relations to render nodes

### DIFF
--- a/demo/camera_controller.hpp
+++ b/demo/camera_controller.hpp
@@ -6,11 +6,8 @@ using namespace glm;
 class CameraController : public Ore::Behavior
 {
 public:
-  CameraController(Ore::WorldNode *node) : Behavior(node)
+  CameraController()
   {
-    camera = node->cast<Ore::Camera *>();
-    prevYaw = Ore::Input::getCursorPosition().x;
-    prevPitch = Ore::Input::getCursorPosition().y;
   }
 
   void onUpdate() override

--- a/demo/cube.hpp
+++ b/demo/cube.hpp
@@ -4,7 +4,7 @@
 class Cube : public Ore::Renderable
 {
 public:
-  Cube(Ore::WorldNode *parent = nullptr) : Ore::Renderable(parent) {}
+  Cube() {}
 
   void bind()
   {

--- a/demo/cube_controller.hpp
+++ b/demo/cube_controller.hpp
@@ -6,7 +6,7 @@ using namespace glm;
 class CubeController : public Ore::Behavior
 {
 public:
-  CubeController(Ore::WorldNode *node) : Ore::Behavior(node) {}
+  CubeController() {}
 
   void onUpdate() override
   {

--- a/ore/ore/engine/core/application.cpp
+++ b/ore/ore/engine/core/application.cpp
@@ -11,6 +11,8 @@ namespace Ore
     scene = SceneLoader::deserialize(path);
     camera = scene->getMainCamera();
     camera->setAspectRatio((float)window->data.width / window->data.height);
+
+    addNode(scene);
   }
 
   void Application::unloadCurrentScene()
@@ -23,6 +25,16 @@ namespace Ore
       // Camera is removed by the scene.
       camera = nullptr;
     }
+  }
+
+  void Application::addNode(Node *node)
+  {
+    nodes.emplace_back(node);
+  }
+
+  void Application::removeNode(Node *node)
+  {
+    nodes.erase(std::remove(nodes.begin(), nodes.end(), node), nodes.end());
   }
 
   bool Application::create(int32_t width, int32_t height, bool fullScreen)
@@ -113,7 +125,8 @@ namespace Ore
     deltaTime = time - lastFrameTime;
     lastFrameTime = time;
 
-    scene->render(camera);
+    for (auto node : nodes)
+      node->render(camera);
 
     glfwSwapBuffers(window->getNative());
   }

--- a/ore/ore/engine/core/application.hpp
+++ b/ore/ore/engine/core/application.hpp
@@ -28,6 +28,9 @@ namespace Ore
     void loadScene(std::string path);
     void unloadCurrentScene();
 
+    void addNode(Node *node);
+    void removeNode(Node *node);
+
     virtual void onStart() {}
     virtual void onDestroy() {}
 
@@ -43,6 +46,8 @@ namespace Ore
     Window *window;
     Scene *scene;
     Camera *camera;
+
+    std::vector<Node *> nodes;
 
   private:
     void destroy();

--- a/ore/ore/engine/core/node_factory.hpp
+++ b/ore/ore/engine/core/node_factory.hpp
@@ -7,12 +7,11 @@
 namespace Ore
 {
   class Node;
-  class WorldNode;
 
   struct NodeFactory
   {
   private:
-    typedef Node *NodeInstantiator(WorldNode *parentNode);
+    typedef Node *NodeInstantiator();
     typedef std::map<std::string, NodeInstantiator *> NodeInstantiators;
     static NodeInstantiators &instantiators()
     {
@@ -21,14 +20,14 @@ namespace Ore
     }
 
   public:
-    static Node *create(const std::string id, WorldNode *parentNode = nullptr)
+    static Node *create(const std::string id)
     {
       // Find the instantiator function for the id.
       const NodeInstantiators::const_iterator iterator = instantiators().find(id);
 
       // If the function is found, execute it to create the new Node.
       if (iterator != instantiators().end())
-        return (*iterator->second)(parentNode);
+        return (*iterator->second)();
 
       std::cout << "Cannot find instantiator function for id " << id << "." << std::endl;
       return 0;
@@ -38,10 +37,9 @@ namespace Ore
     template <class T = int>
     struct Register
     {
-      static Node *create(WorldNode *parentNode = nullptr) { return new T(parentNode); }
+      static Node *create() { return new T(); }
       static NodeInstantiator *withId(const std::string id)
       {
-        std::cout << id << std::endl;
         return instantiators()[id] = create;
       }
       static NodeInstantiator *instantiator;

--- a/ore/ore/engine/core/scene_loader.cpp
+++ b/ore/ore/engine/core/scene_loader.cpp
@@ -46,8 +46,7 @@ namespace Ore
 
       for (auto script : nodeConfig["scripts"])
       {
-        Behavior *behavior = NodeFactory::create(script.as<std::string>(), node)
-                                 ->cast<Behavior *>();
+        Behavior *behavior = NodeFactory::create(script.as<std::string>())->cast<Behavior *>();
         node->addBehavior(behavior);
 
         std::cout << "Added script '" << script.as<std::string>() << "' to '"

--- a/ore/ore/engine/renderer/behavior.hpp
+++ b/ore/ore/engine/renderer/behavior.hpp
@@ -10,7 +10,7 @@ namespace Ore
   class Behavior : public Node
   {
   public:
-    Behavior(WorldNode *node) : Node(node), node(node) {}
+    Behavior() {}
     ~Behavior() = default;
 
     void onEvent(Events::Event &event)

--- a/ore/ore/engine/renderer/camera.cpp
+++ b/ore/ore/engine/renderer/camera.cpp
@@ -4,7 +4,7 @@ ORE_REGISTER_NODE(Ore::Camera, "ore_camera");
 
 namespace Ore
 {
-  Camera::Camera(Node *parent) : WorldNode(parent)
+  Camera::Camera()
   {
     targetFront = vec3(0.0f, 0.0f, -1.0f);
     position = vec3(0.0f, 0.0f, -5.0f);

--- a/ore/ore/engine/renderer/camera.hpp
+++ b/ore/ore/engine/renderer/camera.hpp
@@ -10,7 +10,7 @@ namespace Ore
   class Camera : public WorldNode
   {
   public:
-    Camera(Node *parent = nullptr);
+    Camera();
     ~Camera();
 
     /**

--- a/ore/ore/engine/renderer/node.cpp
+++ b/ore/ore/engine/renderer/node.cpp
@@ -1,35 +1,37 @@
 #include "ore/engine/renderer/node.hpp"
 #include "ore/engine/renderer/renderable.hpp"
-#include "ore/engine/renderer/behavior.hpp"
+#include "ore/engine/renderer/camera.hpp"
 
 ORE_REGISTER_NODE(Ore::Node, "ore_node");
 
 namespace Ore
 {
-  Node::~Node()
-  {
-    for (auto behavior : behaviors)
-    {
-      delete behavior;
-      behavior = nullptr;
-    }
-    behaviors.clear();
-  }
-
-  void Node::addBehavior(Behavior *behavior)
-  {
-    behaviors.emplace_back(behavior);
-  }
-
   void Node::onUpdate()
   {
-    for (auto behavior : behaviors)
-      behavior->onUpdate();
+    for (auto child : children)
+      child->onUpdate();
   }
 
   void Node::onEvent(Events::Event &event)
   {
-    for (auto behavior : behaviors)
-      behavior->onEvent(event);
+    for (auto child : children)
+      child->onEvent(event);
+  }
+
+  void Node::render(Camera *camera)
+  {
+    for (auto child : children)
+      child->render(camera);
+  }
+
+  void Node::addChild(Node *child)
+  {
+    child->setParent(this);
+    children.emplace_back(child);
+  }
+
+  std::vector<Node *> Node::getChildren()
+  {
+    return children;
   }
 } // namespace Ore

--- a/ore/ore/engine/renderer/node.hpp
+++ b/ore/ore/engine/renderer/node.hpp
@@ -8,16 +8,27 @@
 namespace Ore
 {
   class Behavior;
+  class Camera;
 
   class Node
   {
   public:
-    Node(Node *parent = nullptr) { this->parent = parent; };
-    ~Node();
+    Node() {}
+    ~Node() {}
 
-    void addBehavior(Behavior *behavior);
+    /**
+     * @brief Callback for frame update.
+     */
     virtual void onUpdate();
+
+    /**
+     * @brief Callback for event.
+     *
+     * @param event The triggered event.
+     */
     virtual void onEvent(Events::Event &event);
+
+    virtual void render(Camera *camera);
 
     template <typename T>
     bool isA() { return typeid(*this) == typeid(T); }
@@ -30,10 +41,13 @@ namespace Ore
 
     bool hasParent() { return parent != nullptr; }
     Node *getParent() { return parent; }
+    void setParent(Node *parent) { this->parent = parent; }
+
+    void addChild(Node *child);
+    std::vector<Node *> getChildren();
 
   private:
-    std::vector<Behavior *> behaviors;
-
     Node *parent;
+    std::vector<Node *> children;
   };
 } // namespace Ore

--- a/ore/ore/engine/renderer/renderable.hpp
+++ b/ore/ore/engine/renderer/renderable.hpp
@@ -13,7 +13,7 @@ namespace Ore
   class Renderable : public WorldNode
   {
   public:
-    Renderable(WorldNode *parent = nullptr) : WorldNode(parent) {}
+    Renderable() {}
     ~Renderable() = default;
 
     virtual void useShader(Shader *shader);

--- a/ore/ore/engine/renderer/scene.cpp
+++ b/ore/ore/engine/renderer/scene.cpp
@@ -5,12 +5,12 @@
 
 namespace Ore
 {
-  void Scene::addNode(Node *node)
+  void Scene::addNode(WorldNode *node)
   {
     nodes.emplace_back(std::move(node));
   }
 
-  std::vector<Node *> Scene::getNodes() const
+  std::vector<WorldNode *> Scene::getNodes() const
   {
     return nodes;
   }
@@ -25,10 +25,6 @@ namespace Ore
       if (node->isDerivedFrom<Renderable>())
         dynamic_cast<Renderable *>(node)->render(camera);
     }
-  }
-
-  Scene::Scene()
-  {
   }
 
   Scene::~Scene()

--- a/ore/ore/engine/renderer/scene.hpp
+++ b/ore/ore/engine/renderer/scene.hpp
@@ -10,21 +10,21 @@ namespace Ore
 {
   class SceneLoader;
 
-  class Scene
+  class Scene : public Node
   {
   public:
-    Scene();
+    Scene() {}
     ~Scene();
 
     void render(Camera *camera);
 
-    void addNode(Node *node);
-    std::vector<Node *> getNodes() const;
+    void addNode(WorldNode *node);
+    std::vector<WorldNode *> getNodes() const;
 
     Camera *getMainCamera() { return mainCamera; }
 
   private:
-    std::vector<Node *> nodes;
+    std::vector<WorldNode *> nodes;
     Camera *mainCamera;
 
   private:

--- a/ore/ore/engine/renderer/world_node.cpp
+++ b/ore/ore/engine/renderer/world_node.cpp
@@ -1,7 +1,25 @@
 #include "ore/engine/renderer/world_node.hpp"
+#include "ore/engine/renderer/behavior.hpp"
 
 namespace Ore
 {
+  WorldNode::~WorldNode()
+  {
+
+    for (auto behavior : behaviors)
+    {
+      delete behavior;
+      behavior = nullptr;
+    }
+    behaviors.clear();
+  }
+
+  void WorldNode::addBehavior(Behavior *behavior)
+  {
+    behavior->setParent(this);
+    behaviors.emplace_back(behavior);
+  }
+
   vec3 WorldNode::getPosition()
   {
     return position;

--- a/ore/ore/engine/renderer/world_node.hpp
+++ b/ore/ore/engine/renderer/world_node.hpp
@@ -7,69 +7,79 @@ using namespace glm;
 
 namespace Ore
 {
+  class Behavior;
+
   class WorldNode : public Node
   {
   public:
-    WorldNode(Node *parent = nullptr) : Node(parent) {}
+    WorldNode() {}
+    ~WorldNode();
 
     /**
-   * @brief Get the current position of the node.
-   */
+     * @brief Add a bevavior to control this node.
+     */
+    void addBehavior(Behavior *behavior);
+
+    /**
+     * @brief Get the current position of the node.
+     */
     virtual vec3 getPosition();
 
     /**
-   * @brief Translate the node relative to the current position.
-   */
+     * @brief Translate the node relative to the current position.
+     */
     virtual void translate(vec3 translation);
 
     /**
-   * @brief Translate the node to the given position.
-   */
+     * @brief Translate the node to the given position.
+     */
     virtual void translateTo(vec3 position);
 
     /**
-   * @brief Rotate relatively.
-   *
-   * @param angle The angle to rotate
-   * @param axes The axes to rotate on
-   */
+     * @brief Rotate relatively.
+     *
+     * @param angle The angle to rotate
+     * @param axes The axes to rotate on
+     */
     virtual void rotate(float angle, vec3 axes);
 
     /**
-   * @brief Set absolute rotation.
-   *
-   * @param angle The angle to rotate
-   * @param axes The axes to rotate on
-   */
+     * @brief Set absolute rotation.
+    *
+    * @param angle The angle to rotate
+    * @param axes The axes to rotate on
+    */
     virtual void rotateTo(float angle, vec3 axes);
 
     /**
-   * @brief Scale on individual axes.
-   */
+     * @brief Scale on individual axes.
+     */
     virtual void scale(vec3 scale);
 
     /**
-   * @brief Scale on all axes.
-   */
+     * @brief Scale on all axes.
+     */
     virtual void scale(float scale);
 
   protected:
     /**
-   * @brief Object position.
-   *
-   */
+     * @brief The list of behaviors to call each update.
+     */
+    std::vector<Behavior *> behaviors;
+
+    /**
+     * @brief Object position.
+     */
     vec3 position = vec3(1.0f);
 
     /**
-   * @brief Object rotation.
-   *
-   */
+     * @brief Object rotation.
+     */
     vec4 rotation = vec4(1.0f);
 
     /**
-   * @brief Object scale.
-   *
-   */
+     * @brief Object scale.
+     */
     vec3 scaling = vec3(1.0f);
   };
 } // namespace Ore


### PR DESCRIPTION
The `Scene` type has been transformed into a `Node` type. This was necessary to be able to add other nodes for the Rock editor outside a scene. Because a `Scene` is now a `Node` type it was time to implement the tree-like structure with parent-child relations. This enables me to create `Node` that are dependent of each other.

The image below illustrates what `Node` types are available right now and what the inheritance looks like. 

![application-model](https://user-images.githubusercontent.com/10500389/146785645-86a4a4fa-9487-4987-8d97-0e0fd3343c62.png)

